### PR TITLE
Rewards should now respect main enable and autocontribute toggles

### DIFF
--- a/include/bat/ledger/ledger.h
+++ b/include/bat/ledger/ledger.h
@@ -126,6 +126,7 @@ class LEDGER_EXPORT Ledger {
                                     const ledger::PublisherInfoFilter& filter,
                                     GetPublisherInfoListCallback callback) = 0;
 
+  virtual void SetRewardsMainEnabled(bool enabled) = 0;
   virtual void SetPublisherMinVisitTime(uint64_t duration_in_seconds) = 0;
   virtual void SetPublisherMinVisits(unsigned int visits) = 0;
   virtual void SetPublisherAllowNonVerified(bool allow) = 0;
@@ -141,6 +142,7 @@ class LEDGER_EXPORT Ledger {
   virtual const std::string& GetETHAddress() const = 0;
   virtual const std::string& GetLTCAddress() const = 0;
   virtual uint64_t GetReconcileStamp() const = 0;
+  virtual bool GetRewardsMainEnabled() const = 0;
   virtual uint64_t GetPublisherMinVisitTime() const = 0; // In milliseconds
   virtual unsigned int GetPublisherMinVisits() const = 0;
   virtual bool GetPublisherAllowNonVerified() const = 0;

--- a/src/bat_client.cc
+++ b/src/bat_client.cc
@@ -179,6 +179,15 @@ double BatClient::getContributionAmount() const {
   return state_->fee_amount_;
 }
 
+void BatClient::setRewardsMainEnabled(const bool& enabled) {
+  state_->rewards_enabled_ = enabled;
+  saveState();
+}
+
+bool BatClient::getRewardsMainEnabled() const {
+  return state_->rewards_enabled_;
+}
+
 void BatClient::setAutoContribute(const bool& enabled) {
   state_->auto_contribute_ = enabled;
   saveState();

--- a/src/bat_client.h
+++ b/src/bat_client.h
@@ -24,6 +24,8 @@ class BatClient {
   explicit BatClient(bat_ledger::LedgerImpl* ledger);
   ~BatClient();
 
+  void setRewardsMainEnabled(const bool& enabled);
+  bool getRewardsMainEnabled() const;
   bool loadState(const std::string& data);
   void registerPersona();
   void requestCredentialsCallback(bool result, const std::string& response);

--- a/src/bat_helper.cc
+++ b/src/bat_helper.cc
@@ -508,7 +508,8 @@ static bool ignore_ = false;
     settings_(AD_FREE_SETTINGS),
     fee_amount_(0),
     days_(0),
-    auto_contribute_(true) {}
+    auto_contribute_(true),
+    rewards_enabled_(true) {}
 
   CLIENT_STATE_ST::CLIENT_STATE_ST(const CLIENT_STATE_ST& other) {
     walletInfo_ = other.walletInfo_;
@@ -529,6 +530,7 @@ static bool ignore_ = false;
     rulesetV2_ = other.rulesetV2_;
     batch_ = other.batch_;
     auto_contribute_ = other.auto_contribute_;
+    rewards_enabled_ = other.rewards_enabled_;
   }
 
   CLIENT_STATE_ST::~CLIENT_STATE_ST() {}
@@ -557,7 +559,8 @@ static bool ignore_ = false;
         d.HasMember("ruleset") && d["ruleset"].IsString() &&
         d.HasMember("rulesetV2") && d["rulesetV2"].IsString() &&
         d.HasMember("batch") && d["batch"].IsArray() &&
-        d.HasMember("auto_contribute") && d["auto_contribute"].IsBool()
+        d.HasMember("auto_contribute") && d["auto_contribute"].IsBool() &&
+        d.HasMember("rewards_enabled") && d["rewards_enabled"].IsBool()
       );
     }
 
@@ -582,6 +585,7 @@ static bool ignore_ = false;
       fee_amount_ = d["fee_amount"].GetDouble();
       days_ = d["days"].GetUint();
       auto_contribute_ = d["auto_contribute"].GetBool();
+      rewards_enabled_ = d["rewards_enabled"].GetBool();
 
       for (const auto & i : d["transactions"].GetArray()) {
         rapidjson::StringBuffer sb;
@@ -658,6 +662,9 @@ static bool ignore_ = false;
 
     writer.String("days");
     writer.Uint(data.days_);
+
+    writer.String("rewards_enabled");
+    writer.Bool(data.rewards_enabled_);
 
     writer.String("auto_contribute");
     writer.Bool(data.auto_contribute_);

--- a/src/bat_helper.h
+++ b/src/bat_helper.h
@@ -207,6 +207,7 @@ namespace braveledger_bat_helper {
     std::vector<BATCH_VOTES_ST> batch_;
     GRANT grant_;
     bool auto_contribute_ = true;
+    bool rewards_enabled_ = true;
   };
 
   struct REPORT_BALANCE_ST {

--- a/src/bat_publishers.cc
+++ b/src/bat_publishers.cc
@@ -91,17 +91,19 @@ void BatPublishers::MakePayment(const ledger::PaymentData& payment_data) {
 void BatPublishers::saveVisit(const std::string& publisher_id,
                               const ledger::VisitData& visit_data,
                               const uint64_t& duration) {
-  if (publisher_id.empty() || (!ignoreMinTime(publisher_id) &&
-      duration < state_->min_pubslisher_duration_))
-    return;
+  if (ledger_->GetRewardsMainEnabled() && ledger_->GetAutoContribute()) {
+    if (publisher_id.empty() || (!ignoreMinTime(publisher_id) &&
+        duration < state_->min_pubslisher_duration_))
+      return;
 
-  auto filter = CreatePublisherFilter(publisher_id,
-      ledger::PUBLISHER_CATEGORY::AUTO_CONTRIBUTE,
-      visit_data.local_month,
-      visit_data.local_year);
-  ledger_->GetPublisherInfo(filter,
-      std::bind(&BatPublishers::saveVisitInternal, this,
-          publisher_id, visit_data, duration, _1, _2));
+    auto filter = CreatePublisherFilter(publisher_id,
+        ledger::PUBLISHER_CATEGORY::AUTO_CONTRIBUTE,
+        visit_data.local_month,
+        visit_data.local_year);
+    ledger_->GetPublisherInfo(filter,
+        std::bind(&BatPublishers::saveVisitInternal, this,
+            publisher_id, visit_data, duration, _1, _2));
+  }
 }
 
 ledger::PublisherInfoFilter BatPublishers::CreatePublisherFilter(

--- a/src/ledger_impl.cc
+++ b/src/ledger_impl.cc
@@ -314,6 +314,10 @@ void LedgerImpl::GetPublisherInfoList(uint32_t start, uint32_t limit,
   ledger_client_->LoadPublisherInfoList(start, limit, filter, callback);
 }
 
+void LedgerImpl::SetRewardsMainEnabled(bool enabled) {
+  bat_client_->setRewardsMainEnabled(enabled);
+}
+
 void LedgerImpl::SetPublisherMinVisitTime(uint64_t duration) { // In seconds
   bat_publishers_->setPublisherMinVisitTime(duration);
 }
@@ -336,6 +340,10 @@ void LedgerImpl::SetContributionAmount(double amount) {
 
 void LedgerImpl::SetAutoContribute(bool enabled) {
   bat_client_->setAutoContribute(enabled);
+}
+
+bool LedgerImpl::GetRewardsMainEnabled() const {
+  return bat_client_->getRewardsMainEnabled();
 }
 
 uint64_t LedgerImpl::GetPublisherMinVisitTime() const {

--- a/src/ledger_impl.h
+++ b/src/ledger_impl.h
@@ -61,6 +61,7 @@ class LedgerImpl : public ledger::Ledger,
                             const ledger::PublisherInfoFilter& filter,
                             ledger::GetPublisherInfoListCallback callback) override;
 
+  void SetRewardsMainEnabled(bool enabled) override;
   void SetPublisherMinVisitTime(uint64_t duration_in_seconds) override;
   void SetPublisherMinVisits(unsigned int visits) override;
   void SetPublisherAllowNonVerified(bool allow) override;
@@ -76,6 +77,7 @@ class LedgerImpl : public ledger::Ledger,
   const std::string& GetETHAddress() const override;
   const std::string& GetLTCAddress() const override;
   uint64_t GetReconcileStamp() const override;
+  bool GetRewardsMainEnabled() const override;
   uint64_t GetPublisherMinVisitTime() const override; // In milliseconds
   unsigned int GetPublisherMinVisits() const override;
   bool GetPublisherAllowNonVerified() const override;


### PR DESCRIPTION
Resolves #58 

Updates for Rewards to not save visit data when rewards is off. Also does not add to autocontribute when autocontribute is off.