### PR TITLE
Placing call to GetRewardsMainEnabled back in

### DIFF
--- a/src/bat_publishers.cc
+++ b/src/bat_publishers.cc
@@ -89,7 +89,7 @@ void BatPublishers::MakePayment(const ledger::PaymentData& payment_data) {
 }
 
 bool BatPublishers::saveVisitAllowed() const {
-  return (ledger_->GetAutoContribute());
+  return (ledger_->GetRewardsMainEnabled() && ledger_->GetAutoContribute());
 }
 
 void BatPublishers::saveVisit(const std::string& publisher_id,


### PR DESCRIPTION
Fixes https://github.com/brave/brave-core/pull/419

This was accidentally removed crossing merges. 

Originally implemented in #87