### PR TITLE
Fix for brave-core tests

### DIFF
--- a/src/static_values.h
+++ b/src/static_values.h
@@ -14,7 +14,7 @@
 #define PUBLISHER_STAGING_SERVER        "https://publishers-staging.basicattentiontoken.org"
 #define PUBLISHER_PRODUCTION_SERVER     "https://publishers.basicattentiontoken.org"
 
-
+#define PREFIX_V1                       "/v1"
 #define PREFIX_V2                       "/v2"
 #define REGISTER_PERSONA                "/registrar/persona"
 #define REGISTER_VIEWING                "/registrar/viewing"


### PR DESCRIPTION
Was getting the following error when running `npm run test -- brave_browser_tests`:
14:13:34 ../../brave/components/brave_rewards/browser/rewards_service_browsertest.cc:68:5: error: use of undeclared identifier 'PREFIX_V1'
14:13:34     PREFIX_V1, braveledger_bat_helper::SERVER_TYPES::LEDGER)) == 0) {
14:13:34     ^
14:13:34 1 error generated.