### PR TITLE
Adding numExcludedSites to publisher state

### DIFF
--- a/include/bat/ledger/ledger.h
+++ b/include/bat/ledger/ledger.h
@@ -146,6 +146,7 @@ class LEDGER_EXPORT Ledger {
   virtual bool GetRewardsMainEnabled() const = 0;
   virtual uint64_t GetPublisherMinVisitTime() const = 0; // In milliseconds
   virtual unsigned int GetPublisherMinVisits() const = 0;
+  virtual unsigned int GetNumExcludedSites() const = 0;
   virtual bool GetPublisherAllowNonVerified() const = 0;
   virtual bool GetPublisherAllowVideos() const = 0;
   virtual double GetContributionAmount() const = 0;

--- a/include/bat/ledger/ledger_client.h
+++ b/include/bat/ledger/ledger_client.h
@@ -80,6 +80,7 @@ class LEDGER_EXPORT LedgerClient {
   virtual void OnPublisherActivity(Result result,
                                    std::unique_ptr<ledger::PublisherInfo>,
                                    uint64_t windowId) = 0;
+  virtual void OnExcludedSitesChanged() = 0;
 
   //uint64_t time_offset (input): timer offset in seconds.
   //uint32_t timer_id (output) : 0 in case of failure

--- a/include/bat/ledger/publisher_info.h
+++ b/include/bat/ledger/publisher_info.h
@@ -37,6 +37,7 @@ LEDGER_EXPORT enum PUBLISHER_MONTH {
 };
 
 LEDGER_EXPORT enum PUBLISHER_EXCLUDE {
+  ALL = -1,
   DEFAULT = 0, // this tell us that user did not manually changed exclude state
   EXCLUDED = 1, // user manually changed it to exclude
   INCLUDED = 2 // user manually changed it to include and is overriding server flags

--- a/src/bat_helper.cc
+++ b/src/bat_helper.cc
@@ -777,6 +777,7 @@ static bool ignore_ = false;
   PUBLISHER_STATE_ST::PUBLISHER_STATE_ST():
     min_pubslisher_duration_(braveledger_ledger::_default_min_pubslisher_duration),
     min_visits_(1),
+    num_excluded_sites_(0),
     allow_non_verified_(true),
     pubs_load_timestamp_ (0ull),
     allow_videos_(true) {}
@@ -784,6 +785,7 @@ static bool ignore_ = false;
   PUBLISHER_STATE_ST::PUBLISHER_STATE_ST(const PUBLISHER_STATE_ST& state) {
     min_pubslisher_duration_ = state.min_pubslisher_duration_;
     min_visits_ = state.min_visits_;
+    num_excluded_sites_ = state.num_excluded_sites_;
     allow_non_verified_ = state.allow_non_verified_;
     pubs_load_timestamp_ = state.pubs_load_timestamp_;
     allow_videos_ = state.allow_videos_;
@@ -802,6 +804,7 @@ static bool ignore_ = false;
     if (false == error) {
       error = !(d.HasMember("min_pubslisher_duration") && d["min_pubslisher_duration"].IsUint() &&
         d.HasMember("min_visits") && d["min_visits"].IsUint() &&
+        d.HasMember("num_excluded_sites") && d["num_excluded_sites"].IsUint() &&
         d.HasMember("allow_non_verified") && d["allow_non_verified"].IsBool() &&
         d.HasMember("pubs_load_timestamp") && d["pubs_load_timestamp"].IsUint64() &&
         d.HasMember("allow_videos") && d["allow_videos"].IsBool() &&
@@ -812,6 +815,7 @@ static bool ignore_ = false;
     if (false == error) {
       min_pubslisher_duration_ = d["min_pubslisher_duration"].GetUint();
       min_visits_ = d["min_visits"].GetUint();
+      num_excluded_sites_ = d["num_excluded_sites"].GetUint();
       allow_non_verified_ = d["allow_non_verified"].GetBool();
       pubs_load_timestamp_ = d["pubs_load_timestamp"].GetUint64();
       allow_videos_ = d["allow_videos"].GetBool();
@@ -860,6 +864,9 @@ static bool ignore_ = false;
 
     writer.String("min_visits");
     writer.Uint(data.min_visits_);
+
+    writer.String("num_excluded_sites");
+    writer.Uint(data.num_excluded_sites_);
 
     writer.String("allow_non_verified");
     writer.Bool(data.allow_non_verified_);

--- a/src/bat_helper.h
+++ b/src/bat_helper.h
@@ -237,6 +237,7 @@ namespace braveledger_bat_helper {
 
     uint64_t min_pubslisher_duration_ = braveledger_ledger::_default_min_pubslisher_duration;  // In seconds
     unsigned int min_visits_ = 1u;
+    unsigned int num_excluded_sites_ = 0;
     bool allow_non_verified_ = true;
     uint64_t pubs_load_timestamp_ = 0ull; //last publishers list load timestamp (seconds)
     bool allow_videos_ = true;

--- a/src/bat_publishers.h
+++ b/src/bat_publishers.h
@@ -50,6 +50,8 @@ class BatPublishers : public ledger::LedgerCallbackHandler {
 
   void setPublishersLastRefreshTimestamp(uint64_t ts);
 
+  void setNumExcludedSites(const unsigned int& amount);
+
   void setExclude(const std::string& publisher_id, const ledger::PUBLISHER_EXCLUDE& exclude);
   void restorePublishers();
 
@@ -67,6 +69,7 @@ class BatPublishers : public ledger::LedgerCallbackHandler {
   unsigned int getPublisherMinVisits() const;
   bool getPublisherAllowNonVerified() const;
   uint64_t getLastPublishersListLoadTimestamp() const;
+  unsigned int getNumExcludedSites() const;
   bool getPublisherAllowVideos() const;
 
   std::vector<braveledger_bat_helper::WINNERS_ST> winners(const unsigned int& ballots);
@@ -131,6 +134,8 @@ class BatPublishers : public ledger::LedgerCallbackHandler {
       ledger::Result result,
       std::unique_ptr<ledger::PublisherInfo> publisher_info);
 
+  void setNumExcludedSitesInternal(ledger::PUBLISHER_EXCLUDE exclude);
+
   void makePaymentInternal(
       ledger::PaymentData payment_data,
       ledger::Result result,
@@ -158,6 +163,8 @@ class BatPublishers : public ledger::LedgerCallbackHandler {
                            std::unique_ptr<ledger::PublisherInfo> publisher_info,
                            uint64_t windowId,
                            const std::string& publisherKey);
+
+  void OnExcludedSitesChanged();
 
   bat_ledger::LedgerImpl* ledger_;  // NOT OWNED
 

--- a/src/ledger_impl.cc
+++ b/src/ledger_impl.cc
@@ -363,6 +363,10 @@ unsigned int LedgerImpl::GetPublisherMinVisits() const {
   return bat_publishers_->getPublisherMinVisits();
 }
 
+unsigned int LedgerImpl::GetNumExcludedSites() const {
+  return bat_publishers_->getNumExcludedSites();
+}
+
 bool LedgerImpl::GetPublisherAllowNonVerified() const {
   return bat_publishers_->getPublisherAllowNonVerified();
 }
@@ -643,6 +647,10 @@ void LedgerImpl::GetMediaActivityFromUrl(uint64_t windowId,
 void LedgerImpl::OnPublisherActivity(ledger::Result result,
                                         std::unique_ptr<ledger::PublisherInfo> info, uint64_t windowId) {
   ledger_client_->OnPublisherActivity(result, std::move(info), windowId);
+}
+
+void LedgerImpl::OnExcludedSitesChanged() {
+  ledger_client_->OnExcludedSitesChanged();
 }
 
 }  // namespace bat_ledger

--- a/src/ledger_impl.h
+++ b/src/ledger_impl.h
@@ -81,6 +81,7 @@ class LedgerImpl : public ledger::Ledger,
   bool GetRewardsMainEnabled() const override;
   uint64_t GetPublisherMinVisitTime() const override; // In milliseconds
   unsigned int GetPublisherMinVisits() const override;
+  unsigned int GetNumExcludedSites() const override;
   bool GetPublisherAllowNonVerified() const override;
   bool GetPublisherAllowVideos() const override;
   double GetContributionAmount() const override;
@@ -151,6 +152,7 @@ class LedgerImpl : public ledger::Ledger,
   void OnPublisherActivity(ledger::Result result,
                            std::unique_ptr<ledger::PublisherInfo> info,
                            uint64_t windowId);
+  void OnExcludedSitesChanged();
 
  private:
   void MakePayment(const ledger::PaymentData& payment_data) override;


### PR DESCRIPTION
Fixes #115 

This adds `num_excluded_sites_` to the publisher state. This value is kept track of internally inside the native-ledger, thus it doesn't need any setter methods in the ledger implementation.

**This should be tested with:** https://github.com/brave/brave-core/pull/475