### PR TITLE
Call to RefreshPublishersList moved to OnPublisherStateLoaded

### DIFF
--- a/src/ledger_impl.cc
+++ b/src/ledger_impl.cc
@@ -195,6 +195,7 @@ void LedgerImpl::OnPublisherStateLoaded(ledger::Result result,
   }
 
   OnWalletInitialized(result);
+  RefreshPublishersList(false);
 }
 
 void LedgerImpl::SaveLedgerState(const std::string& data) {
@@ -234,7 +235,6 @@ void LedgerImpl::OnWalletInitialized(ledger::Result result) {
 
   if (result == ledger::Result::LEDGER_OK) {
     initialized_ = true;
-    RefreshPublishersList(false);
   }
 }
 


### PR DESCRIPTION
Fixes: https://github.com/brave/brave-browser/issues/972

`RefreshPublishersList` was being called directly from `OnWalletInitialized`, which happens before the publishers state is loaded. This would return a `0` value for the publisher list last load timestamp, so it was overwriting resetting the timer every time you'd start the browser. This fix reserves that first call to when the publishers state is actually loaded.

This can be tested on a smaller scale by setting a shorter value for `_publishers_list_load_interval` in `src/static_values.h`