### PR TITLE
Only fetch list if rewards enabled

### DIFF
--- a/src/ledger_impl.cc
+++ b/src/ledger_impl.cc
@@ -31,7 +31,8 @@ LedgerImpl::LedgerImpl(ledger::LedgerClient* client) :
     initializing_(false),
     last_tab_active_time_(0),
     last_shown_tab_id_(-1),
-    last_pub_load_timer_id_ (0u){
+    last_pub_load_timer_id_ (0u),
+    publisher_state_loaded_(false){
 }
 
 LedgerImpl::~LedgerImpl() {
@@ -194,8 +195,8 @@ void LedgerImpl::OnPublisherStateLoaded(ledger::Result result,
     }
   }
 
+  publisher_state_loaded_ = true;
   OnWalletInitialized(result);
-  RefreshPublishersList(false);
 }
 
 void LedgerImpl::SaveLedgerState(const std::string& data) {
@@ -235,6 +236,10 @@ void LedgerImpl::OnWalletInitialized(ledger::Result result) {
 
   if (result == ledger::Result::LEDGER_OK) {
     initialized_ = true;
+
+    if (publisher_state_loaded_) {
+      RefreshPublishersList(false);
+    }
   }
 }
 

--- a/src/ledger_impl.h
+++ b/src/ledger_impl.h
@@ -212,6 +212,7 @@ class LedgerImpl : public ledger::Ledger,
   uint64_t last_tab_active_time_;
   uint32_t last_shown_tab_id_;
   uint32_t last_pub_load_timer_id_;
+  bool publisher_state_loaded_;
  };
 }  // namespace bat_ledger
 


### PR DESCRIPTION
Fixes: #124

The previous fix concerning this: (https://github.com/brave-intl/bat-native-ledger/pull/123) made sure we didn't fetch publishers list more often than needed, but it introduced a case where the list would be fetched even if rewards was not enabled.

This tweak restores the original fetch, but adds an item `publisher_state_loaded_` so we can only refresh the list if the publisher state is loaded, so we don't get the overwrite problem.