### PR TITLE
Grant fetch timestamp is now reset when no grants are available

### DIFF
--- a/src/bat_client.cc
+++ b/src/bat_client.cc
@@ -1096,6 +1096,16 @@ void BatClient::getGrantCallback(bool success,
 
   ledger_->LogResponse(__func__, success, response, headers);
 
+  unsigned int statusCode;
+  std::string error;
+  bool hasResponseError = braveledger_bat_helper::getJSONResponse(
+    response, statusCode, error);
+  if (hasResponseError && statusCode == 404) {
+    ledger_->SetLastGrantLoadTimestamp(time(0));
+    ledger_->OnGrant(ledger::Result::GRANT_NOT_FOUND, properties);
+    return;
+  }
+
   if (!success) {
     ledger_->OnGrant(ledger::Result::LEDGER_ERROR, properties);
     return;

--- a/src/ledger_impl.cc
+++ b/src/ledger_impl.cc
@@ -573,7 +573,8 @@ void LedgerImpl::OnGrant(ledger::Result result, const braveledger_bat_helper::GR
 
   grant.promotionId = properties.promotionId;
   last_grant_check_timer_id_ = 0;
-  RefreshGrant(result != ledger::Result::LEDGER_OK);
+  RefreshGrant(result != ledger::Result::LEDGER_OK &&
+    result != ledger::Result::GRANT_NOT_FOUND);
   ledger_client_->OnGrant(result, grant);
 }
 


### PR DESCRIPTION
Core Implementation: https://github.com/brave/brave-core/pull/807

Also does not attempt retries on error since 404s are considered errors.