### PR TITLE
Splits state

### DIFF
--- a/BUILD.gn
+++ b/BUILD.gn
@@ -65,6 +65,8 @@ source_set("ledger") {
     "src/bat_helper_platform.h",
     "src/bat_publishers.cc",
     "src/bat_publishers.h",
+    "src/bat_state.cc",
+    "src/bat_state.h",
     "src/bignum.cc",
     "src/bignum.h",
     "src/ledger_impl.cc",

--- a/include/bat/ledger/ledger.h
+++ b/include/bat/ledger/ledger.h
@@ -157,8 +157,8 @@ class LEDGER_EXPORT Ledger {
   virtual bool GetPublisherAllowVideos() const = 0;
   virtual double GetContributionAmount() const = 0;
   virtual bool GetAutoContribute() const = 0;
-  virtual void GetWalletProperties() const = 0;
-  virtual void GetGrant(const std::string& lang, const std::string& paymentId) const = 0;
+  virtual void FetchWalletProperties() const = 0;
+  virtual void FetchGrant(const std::string& lang, const std::string& paymentId) const = 0;
   virtual void SolveGrantCaptcha(const std::string& solution) const = 0;
   virtual void GetGrantCaptcha() const = 0;
   virtual std::string GetWalletPassphrase() const = 0;

--- a/include/bat/ledger/ledger_client.h
+++ b/include/bat/ledger/ledger_client.h
@@ -52,7 +52,7 @@ class LEDGER_EXPORT LedgerClient {
   // called when the wallet creation has completed
   virtual std::string GenerateGUID() const = 0;
   virtual void OnWalletInitialized(Result result) = 0;
-  virtual void GetWalletProperties() = 0;
+  virtual void FetchWalletProperties() = 0;
   virtual void OnWalletProperties(Result result,
                                   std::unique_ptr<ledger::WalletInfo>) = 0;
   virtual void OnReconcileComplete(Result result,
@@ -90,7 +90,8 @@ class LEDGER_EXPORT LedgerClient {
                                     PublisherInfoFilter filter,
                                     GetPublisherInfoListCallback callback) = 0;
 
-  virtual void GetGrant(const std::string& lang, const std::string& paymentId) = 0;
+  // TODO this can be removed
+  virtual void FetchGrant(const std::string& lang, const std::string& paymentId) = 0;
   virtual void OnGrant(ledger::Result result, const ledger::Grant& grant) = 0;
   virtual void GetGrantCaptcha() = 0;
   virtual void OnGrantCaptcha(const std::string& image, const std::string& hint) = 0;

--- a/src/bat_client.h
+++ b/src/bat_client.h
@@ -26,37 +26,20 @@ class BatClient {
   explicit BatClient(bat_ledger::LedgerImpl* ledger);
   ~BatClient();
 
-  void setRewardsMainEnabled(const bool& enabled);
-  bool getRewardsMainEnabled() const;
-  bool loadState(const std::string& data);
   void registerPersona();
   void requestCredentialsCallback(bool result, const std::string& response,
       const std::map<std::string, std::string>& headers);
   void registerPersonaCallback(bool result, const std::string& response,
       const std::map<std::string, std::string>& headers);
-  void setContributionAmount(const double& amount);
-  void setUserChangedContribution();
-  void setAutoContribute(const bool& enabled);
-  const std::string& getBATAddress() const;
-  const std::string& getBTCAddress() const;
-  const std::string& getETHAddress() const;
-  const std::string& getLTCAddress() const;
-  void resetReconcileStamp();
-  uint64_t getReconcileStamp() const;
-  bool didUserChangeContributionAmount() const;
-  double getContributionAmount() const;
-  bool getAutoContribute() const;
-  bool isReadyForReconcile();
   braveledger_bat_helper::CURRENT_RECONCILE GetReconcileById(const std::string& viewingId);
   bool SetReconcile(const braveledger_bat_helper::CURRENT_RECONCILE& reconcile);
-  void removeReconcileById(const std::string& viewingId);
   void reconcilePublisherList(const ledger::PUBLISHER_CATEGORY category,
                               const ledger::PublisherInfoList& list);
   void reconcile(const std::string& viewingId,
       const ledger::PUBLISHER_CATEGORY category,
       const std::vector<braveledger_bat_helper::PUBLISHER_ST>& list,
       const std::vector<braveledger_bat_helper::RECONCILE_DIRECTION>& directions = {});
-  unsigned int ballots(const std::string& viewingId);
+  unsigned int getBallotsCount(const std::string& viewingId);
   void votePublishers(const std::vector<std::string>& publishers, const std::string& viewingId);
   void prepareBallots();
   std::string getWalletPassphrase() const;
@@ -67,7 +50,6 @@ class BatClient {
   void setGrant(const std::string& captchaResponse, const std::string& promotionId);
   void getGrantCaptcha();
   void getWalletProperties();
-  bool isWalletCreated() const;
   void prepareVoteBatch();
   void voteBatch();
 
@@ -76,11 +58,8 @@ class BatClient {
   void OnNicewareListLoaded(const std::string& pass_phrase,
                                 ledger::Result result,
                                 const std::string& data);
-  double getBalance() const;
-  uint64_t getLastGrantLoadTimestamp() const;
 
  private:
-  void saveState();
   void getGrantCaptchaCallback(bool result, const std::string& response,
       const std::map<std::string, std::string>& headers);
   void getGrantCallback(bool result, const std::string& response,
@@ -102,10 +81,6 @@ class BatClient {
       const std::vector<std::string>& proofs);
   void voteBatchCallback(const std::string& publisher, bool result, const std::string& response,
       const std::map<std::string, std::string>& headers);
-  //void prepareBallot(const braveledger_bat_helper::BALLOT_ST& ballot, const braveledger_bat_helper::TRANSACTION_ST& transaction);
-  //void commitBallot(const braveledger_bat_helper::BALLOT_ST& ballot, const braveledger_bat_helper::TRANSACTION_ST& transaction);
-  //void prepareBallotCallback(bool result, const std::string& response, const braveledger_bat_helper::FETCH_CALLBACK_EXTRA_DATA_ST& extraData);
-  //void commitBallotCallback(bool result, const std::string& response);
   void vote(const std::string& publisher, const std::string& viewingId);
   void reconcileCallback(const std::string& viewingId, bool result, const std::string& response,
       const std::map<std::string, std::string>& headers);
@@ -123,7 +98,6 @@ class BatClient {
   std::string getAnonizeProof(const std::string& registrarVK, const std::string& id, std::string& preFlight);
 
   bat_ledger::LedgerImpl* ledger_;  // NOT OWNED
-  std::unique_ptr<braveledger_bat_helper::CLIENT_STATE_ST> state_;
 
   bat_ledger::URLRequestHandler handler_;
 };

--- a/src/bat_helper.cc
+++ b/src/bat_helper.cc
@@ -122,7 +122,11 @@ static bool ignore_ = false;
     writer.String(data.addressLTC_.c_str());
 
     writer.String("keyInfoSeed");
-    writer.String(getBase64(data.keyInfoSeed_).c_str());
+    if (data.keyInfoSeed_.size() == 0) {
+      writer.String("");
+    } else {
+      writer.String(getBase64(data.keyInfoSeed_).c_str());
+    }
 
     writer.EndObject();
   }
@@ -1636,7 +1640,13 @@ static bool ignore_ = false;
 
     if (false == error) {
       for (auto & i : d["rates"].GetObject()) {
-        rates.insert(std::make_pair(i.name.GetString(), i.value.GetDouble()));
+        double value = 0.0;
+        if (i.value.IsDouble()) {
+          value = i.value.GetDouble();
+        } else if (i.value.IsString()) {
+          value = std::stod(i.value.GetString());
+        }
+        rates.insert(std::make_pair(i.name.GetString(), value));
       }
     }
     return !error;

--- a/src/bat_helper.h
+++ b/src/bat_helper.h
@@ -295,6 +295,10 @@ namespace braveledger_bat_helper {
     std::vector<PUBLISHER_ST> list_;
   };
 
+  typedef std::vector<TRANSACTION_ST> Transactions;
+  typedef std::vector<BALLOT_ST> Ballots;
+  typedef std::vector<BATCH_VOTES_ST> BatchVotes;
+
   struct CLIENT_STATE_ST {
     CLIENT_STATE_ST();
     CLIENT_STATE_ST(const CLIENT_STATE_ST&);
@@ -318,11 +322,11 @@ namespace braveledger_bat_helper {
     double fee_amount_ = .0;
     bool user_changed_fee_ = false;
     unsigned int days_ = 0u;
-    std::vector<TRANSACTION_ST> transactions_;
-    std::vector<BALLOT_ST> ballots_;
+    Transactions transactions_;
+    Ballots ballots_;
     std::string ruleset_;
     std::string rulesetV2_;
-    std::vector<BATCH_VOTES_ST> batch_;
+    BatchVotes batch_;
     GRANT grant_;
     std::map<std::string, CURRENT_RECONCILE> current_reconciles_;
     bool auto_contribute_ = false;

--- a/src/bat_state.cc
+++ b/src/bat_state.cc
@@ -1,0 +1,322 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#include "bat_state.h"
+#include "ledger_impl.h"
+#include "rapidjson_bat_helper.h"
+
+namespace braveledger_bat_state {
+
+BatState::BatState(bat_ledger::LedgerImpl* ledger) :
+      ledger_(ledger),
+      state_(new braveledger_bat_helper::CLIENT_STATE_ST()) {
+}
+
+BatState::~BatState() {
+}
+
+bool BatState::LoadState(const std::string& data) {
+  braveledger_bat_helper::CLIENT_STATE_ST state;
+  if (!braveledger_bat_helper::loadFromJson(state, data.c_str())) {
+    ledger_->Log(__func__,
+                 ledger::LogLevel::LOG_ERROR,
+                 {"Failed to load client state: ", data});
+    return false;
+  }
+
+  state_.reset(new braveledger_bat_helper::CLIENT_STATE_ST(state));
+
+  bool stateChanged = false;
+
+  // clear old reconciles
+  if (state_->batch_.size() == 0) {
+    state_->current_reconciles_ = {};
+    stateChanged = true;
+  }
+
+  // fix timestamp ms to s conversion
+  if (std::to_string(state_->reconcileStamp_).length() > 10) {
+    state_->reconcileStamp_ = state_->reconcileStamp_ / 1000;
+    stateChanged = true;
+  }
+
+  // fix timestamp ms to s conversion
+  if (std::to_string(state_->bootStamp_).length() > 10) {
+    state_->bootStamp_ = state_->bootStamp_ / 1000;
+    stateChanged = true;
+  }
+
+  if (stateChanged) {
+    SaveState();
+  }
+
+  return true;
+}
+
+void BatState::SaveState() {
+  std::string data;
+  braveledger_bat_helper::saveToJsonString(*state_, data);
+  ledger_->SaveLedgerState(data);
+}
+
+void BatState::AddReconcile(const std::string& viewing_id,
+      const braveledger_bat_helper::CURRENT_RECONCILE& reconcile) {
+  state_->current_reconciles_.insert(std::make_pair(viewing_id, reconcile));
+  SaveState();
+}
+
+bool BatState::UpdateReconcile(
+    const braveledger_bat_helper::CURRENT_RECONCILE& reconcile) {
+  if (state_->current_reconciles_.count(reconcile.viewingId_) == 0) {
+    return false;
+  }
+
+  state_->current_reconciles_[reconcile.viewingId_] = reconcile;
+  SaveState();
+  return true;
+}
+
+braveledger_bat_helper::CURRENT_RECONCILE BatState::GetReconcileById(
+    const std::string& viewingId) const {
+  if (state_->current_reconciles_.count(viewingId) == 0) {
+    ledger_->Log(__func__,
+                ledger::LogLevel::LOG_ERROR,
+                {"Could not find any reconcile tasks with the id ",
+                 viewingId});
+    return braveledger_bat_helper::CURRENT_RECONCILE();
+  }
+
+  return state_->current_reconciles_[viewingId];
+}
+
+bool BatState::ReconcileExists(const std::string& viewingId) const {
+  return state_->current_reconciles_.count(viewingId) > 0;
+}
+
+void BatState::RemoveReconcileById(const std::string& viewingId) {
+  state_->current_reconciles_.erase(
+      state_->current_reconciles_.find(viewingId));
+  SaveState();
+}
+
+void BatState::SetRewardsMainEnabled(bool enabled) {
+  state_->rewards_enabled_ = enabled;
+  SaveState();
+}
+
+bool BatState::GetRewardsMainEnabled() const {
+  return state_->rewards_enabled_;
+}
+
+void BatState::SetContributionAmount(double amount) {
+  state_->fee_amount_ = amount;
+  SaveState();
+}
+
+double BatState::GetContributionAmount() const {
+  return state_->fee_amount_;
+}
+
+void BatState::SetUserChangedContribution() {
+  state_->user_changed_fee_ = true;
+  SaveState();
+}
+
+bool BatState::GetUserChangeContribution() const {
+  return state_->user_changed_fee_;
+}
+
+void BatState::SetAutoContribute(bool enabled) {
+  state_->auto_contribute_ = enabled;
+  SaveState();
+}
+
+bool BatState::GetAutoContribute() const {
+  return state_->auto_contribute_;
+}
+
+const std::string& BatState::GetBATAddress() const {
+  return state_->walletInfo_.addressBAT_;
+}
+
+const std::string& BatState::GetBTCAddress() const {
+  return state_->walletInfo_.addressBTC_;
+}
+
+const std::string& BatState::GetETHAddress() const {
+  return state_->walletInfo_.addressETH_;
+}
+
+const std::string& BatState::GetLTCAddress() const {
+  return state_->walletInfo_.addressLTC_;
+}
+
+uint64_t BatState::GetReconcileStamp() const {
+  return state_->reconcileStamp_;
+}
+
+void BatState::ResetReconcileStamp() {
+  if (ledger::reconcile_time > 0) {
+    state_->reconcileStamp_ = braveledger_bat_helper::currentTime() +
+                                ledger::reconcile_time * 60;
+  } else {
+    state_->reconcileStamp_ = braveledger_bat_helper::currentTime() +
+                                braveledger_ledger::_reconcile_default_interval;
+  }
+  SaveState();
+}
+
+uint64_t BatState::GetLastGrantLoadTimestamp() const {
+  return state_->last_grant_fetch_stamp_;
+}
+
+void BatState::SetLastGrantLoadTimestamp(uint64_t stamp) {
+  state_->last_grant_fetch_stamp_ = stamp;
+  SaveState();
+}
+
+bool BatState::IsWalletCreated() const {
+  return state_->bootStamp_ != 0u;
+}
+
+double BatState::GetBalance() const {
+  return state_->walletProperties_.balance_;
+}
+
+const std::string& BatState::GetPaymentId() const {
+  return state_->walletInfo_.paymentId_;
+}
+
+void BatState::SetPaymentId(const std::string& payment_id) {
+  state_->walletInfo_.paymentId_ = payment_id;
+  SaveState();
+}
+
+const braveledger_bat_helper::GRANT& BatState::GetGrant() const {
+  return state_->grant_;
+}
+
+void BatState::SetGrant(braveledger_bat_helper::GRANT grant) {
+  state_->grant_ = grant;
+  SaveState();
+}
+
+const std::string& BatState::GetPersonaId() const {
+  return state_->personaId_;
+}
+
+void BatState::SetPersonaId(const std::string& persona_id) {
+  state_->personaId_ = persona_id;
+  SaveState();
+}
+
+const std::string& BatState::GetUserId() const {
+  return state_->userId_;
+}
+
+void BatState::SetUserId(const std::string& user_id) {
+  state_->userId_ = user_id;
+  SaveState();
+}
+
+const std::string& BatState::GetRegistrarVK() const {
+  return state_->registrarVK_;
+}
+
+void BatState::SetRegistrarVK(const std::string& registrar_vk) {
+  state_->registrarVK_ = registrar_vk;
+  SaveState();
+}
+
+const std::string& BatState::GetPreFlight() const {
+  return state_->preFlight_;
+}
+
+void BatState::SetPreFlight(const std::string& pre_flight) {
+  state_->preFlight_ = pre_flight;
+  SaveState();
+}
+
+const braveledger_bat_helper::WALLET_INFO_ST& BatState::GetWalletInfo() const {
+  return state_->walletInfo_;
+}
+
+void BatState::SetWalletInfo(
+    const braveledger_bat_helper::WALLET_INFO_ST& wallet_info) {
+  state_->walletInfo_ = wallet_info;
+  SaveState();
+}
+
+const braveledger_bat_helper::WALLET_PROPERTIES_ST&
+BatState::GetWalletProperties() const {
+  return state_->walletProperties_;
+}
+
+void BatState::SetWalletProperties(
+    const braveledger_bat_helper::WALLET_PROPERTIES_ST& properties) {
+  state_->walletProperties_ = properties;
+  SaveState();
+}
+
+unsigned int BatState::GetDays() const {
+  return state_->days_;
+}
+
+void BatState::SetDays(unsigned int days) {
+  state_->days_ = days;
+  SaveState();
+}
+
+const braveledger_bat_helper::Transactions& BatState::GetTransactions() const {
+  return state_->transactions_;
+}
+
+void BatState::SetTransactions(
+    const braveledger_bat_helper::Transactions& transactions) {
+  state_->transactions_ = transactions;
+  SaveState();
+}
+
+const braveledger_bat_helper::Ballots& BatState::GetBallots() const {
+  return state_->ballots_;
+}
+
+void BatState::SetBallots(const braveledger_bat_helper::Ballots& ballots) {
+  state_->ballots_ = ballots;
+  SaveState();
+}
+
+const braveledger_bat_helper::BatchVotes& BatState::GetBatch() const {
+  return state_->batch_;
+}
+
+void BatState::SetBatch(const braveledger_bat_helper::BatchVotes& votes) {
+  state_->batch_ = votes;
+  SaveState();
+}
+
+const std::string& BatState::GetCurrency() const {
+  return state_->fee_currency_;
+}
+
+void BatState::SetCurrency(const std::string &currency) {
+  state_->fee_currency_ = currency;
+  SaveState();
+}
+
+void BatState::SetBootStamp(uint64_t stamp) {
+  state_->bootStamp_ = stamp;
+  SaveState();
+}
+
+const std::string& BatState::GetMasterUserToken() const {
+  return state_->masterUserToken_;
+}
+
+void BatState::SetMasterUserToken(const std::string &token) {
+  state_->masterUserToken_ = token;
+  SaveState();
+}
+
+}  // namespace braveledger_bat_state

--- a/src/bat_state.h
+++ b/src/bat_state.h
@@ -1,0 +1,145 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#ifndef BRAVELEDGER_BAT_CLIENT_STATE_H_
+#define BRAVELEDGER_BAT_CLIENT_STATE_H_
+
+#include "bat_helper.h"
+
+#include <string>
+
+namespace bat_ledger {
+class LedgerImpl;
+}
+
+namespace braveledger_bat_state {
+
+class BatState {
+ public:
+  explicit BatState(bat_ledger::LedgerImpl* ledger);
+  ~BatState();
+
+  bool LoadState(const std::string& data);
+
+  void AddReconcile(
+      const std::string& viewing_id,
+      const braveledger_bat_helper::CURRENT_RECONCILE& reconcile);
+
+  bool UpdateReconcile(
+      const braveledger_bat_helper::CURRENT_RECONCILE& reconcile);
+
+  braveledger_bat_helper::CURRENT_RECONCILE GetReconcileById(
+      const std::string& viewingId) const;
+
+  void RemoveReconcileById(const std::string& viewingId);
+
+  bool ReconcileExists(const std::string& viewingId) const;
+
+  void SetRewardsMainEnabled(bool enabled);
+
+  bool GetRewardsMainEnabled() const;
+
+  void SetContributionAmount(double amount);
+
+  double GetContributionAmount() const;
+
+  void SetUserChangedContribution();
+
+  bool GetUserChangeContribution() const;
+
+  void SetAutoContribute(bool enabled);
+
+  bool GetAutoContribute() const;
+
+  const std::string& GetBATAddress() const;
+
+  const std::string& GetBTCAddress() const;
+
+  const std::string& GetETHAddress() const;
+
+  const std::string& GetLTCAddress() const;
+
+  uint64_t GetReconcileStamp() const;
+
+  void ResetReconcileStamp();
+
+  uint64_t GetLastGrantLoadTimestamp() const;
+
+  void SetLastGrantLoadTimestamp(uint64_t stamp);
+
+  bool IsWalletCreated() const;
+
+  double GetBalance() const;
+
+  const std::string& GetPaymentId () const;
+
+  void SetPaymentId(const std::string& payment_id);
+
+  const braveledger_bat_helper::GRANT& GetGrant() const;
+
+  void SetGrant(braveledger_bat_helper::GRANT grant);
+
+  const std::string& GetPersonaId() const;
+
+  void SetPersonaId(const std::string& persona_id);
+
+  const std::string& GetUserId() const;
+
+  void SetUserId(const std::string& user_id);
+
+  const std::string& GetRegistrarVK() const;
+
+  void SetRegistrarVK(const std::string& registrar_vk);
+
+  const std::string& GetPreFlight() const;
+
+  void SetPreFlight(const std::string& pre_flight);
+
+  const braveledger_bat_helper::WALLET_INFO_ST& GetWalletInfo() const;
+
+  void SetWalletInfo(const braveledger_bat_helper::WALLET_INFO_ST& info);
+
+  const braveledger_bat_helper::WALLET_PROPERTIES_ST&
+  GetWalletProperties() const;
+
+  void SetWalletProperties(
+      const braveledger_bat_helper::WALLET_PROPERTIES_ST& properties);
+
+  unsigned int GetDays() const;
+
+  void SetDays(unsigned int days);
+
+  const braveledger_bat_helper::Transactions& GetTransactions() const;
+
+  void SetTransactions(
+      const braveledger_bat_helper::Transactions& transactions);
+
+  const braveledger_bat_helper::Ballots& GetBallots() const;
+
+  void SetBallots(const braveledger_bat_helper::Ballots& ballots);
+
+  const braveledger_bat_helper::BatchVotes& GetBatch() const;
+
+  void SetBatch(const braveledger_bat_helper::BatchVotes& votes);
+
+  const std::string& GetCurrency() const;
+
+  void SetCurrency(const std::string& currency);
+
+  void SetBootStamp(uint64_t stamp);
+
+  const std::string& GetMasterUserToken() const;
+
+  void SetMasterUserToken(const std::string& token);
+
+ private:
+  void SaveState();
+
+  bat_ledger::LedgerImpl* ledger_;  // NOT OWNED
+  std::unique_ptr<braveledger_bat_helper::CLIENT_STATE_ST> state_;
+};
+
+}  // namespace braveledger_bat_state
+
+#endif  // BRAVELEDGER_BAT_CLIENT_STATE_H_

--- a/src/ledger_impl.h
+++ b/src/ledger_impl.h
@@ -29,6 +29,10 @@ namespace braveledger_bat_publishers {
 class BatPublishers;
 }
 
+namespace braveledger_bat_state {
+class BatState;
+}
+
 namespace bat_ledger {
 
 class LedgerImpl : public ledger::Ledger,
@@ -109,9 +113,9 @@ class LedgerImpl : public ledger::Ledger,
 
   void OnWalletProperties(ledger::Result result,
                           const braveledger_bat_helper::WALLET_PROPERTIES_ST&);
-  void GetWalletProperties() const override;
+  void FetchWalletProperties() const override;
 
-  void GetGrant(const std::string& lang, const std::string& paymentId) const override;
+  void FetchGrant(const std::string& lang, const std::string& paymentId) const override;
   void OnGrant(ledger::Result result, const braveledger_bat_helper::GRANT& grant);
 
   void GetGrantCaptcha() const override;
@@ -200,6 +204,60 @@ class LedgerImpl : public ledger::Ledger,
                    const std::string& response,
                    const std::map<std::string,
                    std::string>& headers);
+  void ResetReconcileStamp();
+  bool UpdateReconcile(
+    const braveledger_bat_helper::CURRENT_RECONCILE& reconcile);
+  void AddReconcile(
+      const std::string& viewing_id,
+      const braveledger_bat_helper::CURRENT_RECONCILE& reconcile);
+
+  const std::string& GetPaymentId() const;
+  void SetPaymentId(const std::string& payment_id);
+  const braveledger_bat_helper::GRANT& GetGrant() const;
+  void SetGrant(braveledger_bat_helper::GRANT grant);
+  const std::string& GetPersonaId() const;
+  void SetPersonaId(const std::string& persona_id);
+  const std::string& GetUserId() const;
+  void SetUserId(const std::string& user_id);
+  const std::string& GetRegistrarVK() const;
+  void SetRegistrarVK(const std::string& registrar_vk);
+  const std::string& GetPreFlight() const;
+  void SetPreFlight(const std::string& pre_flight);
+  const braveledger_bat_helper::WALLET_INFO_ST& GetWalletInfo() const;
+  void SetWalletInfo(const braveledger_bat_helper::WALLET_INFO_ST& info);
+
+  const braveledger_bat_helper::WALLET_PROPERTIES_ST&
+  GetWalletProperties() const;
+
+  void SetWalletProperties(
+      const braveledger_bat_helper::WALLET_PROPERTIES_ST& properties);
+  unsigned int GetDays() const;
+  void SetDays(unsigned int days);
+
+  const braveledger_bat_helper::Transactions& GetTransactions() const;
+  void SetTransactions(
+      const braveledger_bat_helper::Transactions& transactions);
+
+  const braveledger_bat_helper::Ballots& GetBallots() const;
+  void SetBallots(
+      const braveledger_bat_helper::Ballots& ballots);
+
+  const braveledger_bat_helper::BatchVotes& GetBatch() const;
+  void SetBatch(
+      const braveledger_bat_helper::BatchVotes& votes);
+
+  const std::string& GetCurrency() const;
+  void SetCurrency(const std::string& currency);
+
+  void SetLastGrantLoadTimestamp(uint64_t stamp);
+
+  void SetBootStamp(uint64_t stamp);
+
+  const std::string& GetMasterUserToken() const;
+
+  void SetMasterUserToken(const std::string& token);
+
+  bool ReconcileExists(const std::string& viewingId);
 
  private:
   void MakePayment(const ledger::PaymentData& payment_data) override;
@@ -261,6 +319,7 @@ class LedgerImpl : public ledger::Ledger,
   std::unique_ptr<braveledger_bat_client::BatClient> bat_client_;
   std::unique_ptr<braveledger_bat_publishers::BatPublishers> bat_publishers_;
   std::unique_ptr<braveledger_bat_get_media::BatGetMedia> bat_get_media_;
+  std::unique_ptr<braveledger_bat_state::BatState> bat_state_;
   bool initialized_;
   bool initializing_;
 


### PR DESCRIPTION
core implementation: https://github.com/brave/brave-core/pull/814

In this PR I moved client state into separate class so it's not coupled to bat_client anymore. Now all other classes can use it the same way via ledgerImpl.

This was done, because I will decoupled contribution from from bat_client into separate class. This will be a base for retry logic.