### PR TITLE
Adding provider to ledger::PublisherBanner

### DIFF
--- a/include/bat/ledger/publisher_info.h
+++ b/include/bat/ledger/publisher_info.h
@@ -90,6 +90,7 @@ LEDGER_EXPORT struct PublisherBanner {
   std::string background;
   std::string logo;
   std::vector<int> amounts;
+  std::string provider;
   std::map<std::string, std::string> social;
 };
 

--- a/src/bat/ledger/ledger.cc
+++ b/src/bat/ledger/ledger.cc
@@ -111,6 +111,7 @@ PublisherBanner::PublisherBanner(const PublisherBanner& info) :
     background(info.background),
     logo(info.logo),
     amounts(info.amounts),
+    provider(info.provider),
     social(info.social) {}
 
 PublisherBanner::~PublisherBanner() {}

--- a/src/bat_publishers.cc
+++ b/src/bat_publishers.cc
@@ -904,6 +904,7 @@ void BatPublishers::onPublisherBanner(ledger::PublisherBannerCallback callback,
   }
 
   new_banner->name = publisher_info->name;
+  new_banner->provider = publisher_info->provider;
 
   if (new_banner->logo.empty()) {
     new_banner->logo = publisher_info->favicon_url;


### PR DESCRIPTION
Related issue: https://github.com/brave/brave-browser/issues/2238

Test with core integration: https://github.com/brave/brave-core/pull/976

Adds provider attribute to `PublisherBanner`. This attribute is set from a `PublisherInfo` object in `BatPublishers::onPublisherBanner`