### PR TITLE
Adds publisherKey to OnExcludedSitesChanged callback

### DIFF
--- a/include/bat/ledger/ledger_client.h
+++ b/include/bat/ledger/ledger_client.h
@@ -111,7 +111,7 @@ class LEDGER_EXPORT LedgerClient {
   virtual void OnPublisherActivity(Result result,
                                    std::unique_ptr<ledger::PublisherInfo>,
                                    uint64_t windowId) = 0;
-  virtual void OnExcludedSitesChanged() = 0;
+  virtual void OnExcludedSitesChanged(const std::string& publisher_id) = 0;
   virtual void FetchFavIcon(const std::string& url,
                             const std::string& favicon_key,
                             FetchIconCallback callback) = 0;

--- a/src/bat_publishers.cc
+++ b/src/bat_publishers.cc
@@ -336,10 +336,12 @@ void BatPublishers::onSetExcludeInternal(ledger::PUBLISHER_EXCLUDE exclude,
   publisher_info->month = ledger::PUBLISHER_MONTH::ANY;
   setNumExcludedSitesInternal(exclude);
 
+  std::string publisherKey = publisher_info->id;
+
   ledger_->SetPublisherInfo(std::move(publisher_info),
     std::bind(&BatPublishers::onSetPublisherInfo, this, _1, _2));
 
-  OnExcludedSitesChanged();
+  OnExcludedSitesChanged(publisherKey);
 }
 
 void BatPublishers::onSetPublisherInfo(ledger::Result result,
@@ -375,10 +377,13 @@ void BatPublishers::onSetPanelExcludeInternal(ledger::PUBLISHER_EXCLUDE exclude,
   setNumExcludedSitesInternal(exclude);
 
   ledger::VisitData visit_data;
+  std::string publisherKey = publisher_info->id;
+
   ledger_->SetPublisherInfo(std::move(publisher_info),
       std::bind(&BatPublishers::onPublisherActivity, this, _1, _2,
       windowId, visit_data));
-  OnExcludedSitesChanged();
+
+  OnExcludedSitesChanged(publisherKey);
 }
 
 void BatPublishers::restorePublishers() {
@@ -820,8 +825,8 @@ void BatPublishers::onPublisherActivity(ledger::Result result,
   }
 }
 
-void BatPublishers::OnExcludedSitesChanged() {
-  ledger_->OnExcludedSitesChanged();
+void BatPublishers::OnExcludedSitesChanged(const std::string& publisher_id) {
+  ledger_->OnExcludedSitesChanged(publisher_id);
 }
 
 void BatPublishers::setBalanceReportItem(ledger::PUBLISHER_MONTH month,

--- a/src/bat_publishers.h
+++ b/src/bat_publishers.h
@@ -191,7 +191,7 @@ class BatPublishers : public ledger::LedgerCallbackHandler {
                            uint64_t windowId,
                            const ledger::VisitData& visit_data);
 
-  void OnExcludedSitesChanged();
+  void OnExcludedSitesChanged(const std::string& publisher_id);
 
   void onPublisherBanner(ledger::PublisherBannerCallback callback,
                          ledger::PublisherBanner banner,

--- a/src/ledger_impl.cc
+++ b/src/ledger_impl.cc
@@ -754,8 +754,8 @@ void LedgerImpl::OnPublisherActivity(ledger::Result result,
   ledger_client_->OnPublisherActivity(result, std::move(info), windowId);
 }
 
-void LedgerImpl::OnExcludedSitesChanged() {
-  ledger_client_->OnExcludedSitesChanged();
+void LedgerImpl::OnExcludedSitesChanged(const std::string& publisher_id) {
+  ledger_client_->OnExcludedSitesChanged(publisher_id);
 }
 
 void LedgerImpl::SetBalanceReportItem(ledger::PUBLISHER_MONTH month,

--- a/src/ledger_impl.h
+++ b/src/ledger_impl.h
@@ -168,7 +168,7 @@ class LedgerImpl : public ledger::Ledger,
   void OnPublisherActivity(ledger::Result result,
                            std::unique_ptr<ledger::PublisherInfo> info,
                            uint64_t windowId);
-  void OnExcludedSitesChanged();
+  void OnExcludedSitesChanged(const std::string& publisher_id);
   void SetBalanceReportItem(ledger::PUBLISHER_MONTH month,
                             int year,
                             ledger::ReportType type,


### PR DESCRIPTION
This is so that the publisher key of the publisher whose exclude attribute was updated can be reported back to the UI

core implementation: https://github.com/brave/brave-core/pull/1010